### PR TITLE
Build documentation

### DIFF
--- a/.github/workflows/docs_website.yml
+++ b/.github/workflows/docs_website.yml
@@ -1,0 +1,86 @@
+name: Documentation website
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache conda
+        uses: actions/cache@v4
+        with:
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-conda-${{hashFiles('environment.yml') }}
+
+      - uses: conda-incubator/setup-miniconda@v3
+        name: Install dependencies
+        with:
+          environment-file: doc/environment.yml
+          auto-activate-base: false
+          miniforge-version: latest
+          use-mamba: true
+
+      - name: Describe environment
+        run: |
+          pwd
+          ls
+          conda list
+
+      - name: Install MLIPOps
+        run: |
+          pip install .
+
+      - name: Build Sphinx documentation
+        run: |
+          cd doc
+          make html
+
+      - name: Checkout gh-pages
+        if: success()
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: 'deploy'
+          clean: false
+
+      - name: Prepare development deployment
+        if: success() && github.event_name == 'push'
+        run: |
+          rm -rf deploy/dev
+          mv doc/build/html deploy/dev
+
+      - name: Prepare release deployment
+        if: success() && github.event_name == 'release'
+        run: |
+          rm -rf deploy/${{  github.ref_name }}
+          mkdir -p deploy/${{  github.ref_name }}
+          mv -T doc/build/html deploy/${{  github.ref_name }}
+          rm -rf deploy/latest
+          ln -s ${{  github.ref_name }} deploy/latest
+
+      - name: Deploy to GitHub Pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages
+          build_dir: deploy
+          jekyll: false
+          commit_message: "Deploy to GH Pages"
+          keep_history: true
+          follow_symlinks: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
This adds a workflow for building the documentation.  When a PR is merged, it will rebuild the `dev` documentation.  When a release is created, it will rebuild the `latest` documentation.

At least that's the goal.  This was mostly just copied from OpenMM-ML.  I guess when this PR is merged we'll find out whether the first part works, and when we create a release we'll find out whether the second part works.