### PR TITLE
Support external potentials

### DIFF
--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -293,6 +293,16 @@ charges = eq(positions, electronegativity, hardness, radius, molecules=molecules
 This produces more accurate results, but it requires you to know in advance how the atoms are grouped into molecules,
 and what the total charge of each molecule should be.
 
+You can specify an externally imposed electric field that should influence the charge distribution.  To do this, pass
+an extra argument containing the external potential at the location of each atom.  A common use for this feature is in
+ML/MM simulations, where charges in the MM region should polarize the ML region.  In this case, you can use
+`compute_potential()` to determine the potential induced by the MM charges.
+
+```python
+potential = coulomb.compute_potential(ml_positions, mm_positions, mm_charges)
+ml_charges = eq(ml_positions, electronegativity, hardness, radius, total_charge=0, potential=potential)
+```
+
 ### Dispersion
 
 Dispersion energy can be computed using the DFT-D3(BJ) model.  Using it is similar to the Coulomb examples shown above,

--- a/mlipops/chargeequilibration.py
+++ b/mlipops/chargeequilibration.py
@@ -38,7 +38,7 @@ class ChargeEquilibration(torch.nn.Module):
 
     def forward(self, positions: torch.Tensor, electronegativity: torch.Tensor, hardness: torch.Tensor,
                 radius: torch.Tensor, total_charge: float | None = None, molecules: list | None = None,
-                box_vectors: torch.Tensor | None = None) -> torch.Tensor:
+                box_vectors: torch.Tensor | None = None, potential: torch.Tensor | None = None) -> torch.Tensor:
         """Perform charge equilibration to compute atomic partial charges.
 
         Parameters
@@ -60,6 +60,8 @@ class ChargeEquilibration(torch.nn.Module):
         box_vectors: torch.Tensor | None
             a Tensor of shape (3, 3) containing box vectors defining the periodic box.  If None, periodic boundary
             conditions are not used.
+        potential: torch.Tensor
+            a Tensor of shape (n_particles,) containing the external electric potential at the location of each particle
 
         Returns
         -------
@@ -107,7 +109,10 @@ class ChargeEquilibration(torch.nn.Module):
 
         matrix = torch.cat([torch.cat([interaction, constraint], dim=1),
                             torch.cat([constraint.T, zeros], dim=1)])
-        x = torch.cat([-electronegativity, mol_charges])
+        rhs = electronegativity
+        if potential is not None:
+            rhs = rhs+potential
+        x = torch.cat([-rhs, mol_charges])
         return torch.linalg.solve(matrix, x)[:n]
 
 

--- a/mlipops/coulomb.py
+++ b/mlipops/coulomb.py
@@ -18,12 +18,12 @@ def dipole_interaction(pairs, r, delta, params):
     c2 = charge[p2]
     d1 = dipole[p1]
     d2 = dipole[p2]
-    d1delta = (d1*delta).sum(axis=1)
-    d2delta = (d2*delta).sum(axis=1)
+    d1delta = (d1*delta).sum(dim=1)
+    d2delta = (d2*delta).sum(dim=1)
     denom3 = r**-3
     energy_cc = c1*c2/r
     energy_cd = (c2*d1delta - c1*d2delta)*denom3
-    energy_dd = ((d1*d2).sum(axis=1) - 3*d1delta*d2delta*r**-2)*denom3
+    energy_dd = ((d1*d2).sum(dim=1) - 3*d1delta*d2delta*r**-2)*denom3
     return energy_cc + energy_cd + energy_dd
 
 
@@ -77,8 +77,8 @@ class ErfcScaledDipoleInteraction(object):
         c2 = charge[p2]
         d1 = dipole[p1]
         d2 = dipole[p2]
-        d1delta = (d1*delta).sum(axis=1)
-        d2delta = (d2*delta).sum(axis=1)
+        d1delta = (d1*delta).sum(dim=1)
+        d2delta = (d2*delta).sum(dim=1)
         alphar = self.alpha*r
         rinv2 = r**-2
         expfactor = torch.exp(-alphar**2)
@@ -89,7 +89,7 @@ class ErfcScaledDipoleInteraction(object):
         b1 = rinv2*(b0 + self.temp1*expfactor)
         b2 = rinv2*(3*b1 + self.temp2*expfactor)
         g0 = c1*c2
-        g1 = c2*d1delta - c1*d2delta + (d1*d2).sum(axis=1)
+        g1 = c2*d1delta - c1*d2delta + (d1*d2).sum(dim=1)
         g2 = -d1delta*d2delta
         return (b0*g0 + b1*g1 + b2*g2)
 

--- a/mlipops/coulombewald.py
+++ b/mlipops/coulombewald.py
@@ -28,8 +28,8 @@ class CoulombEwald(torch.nn.Module):
     included in reciprocal space.  The sum of the two terms thus yields the correct energy with the interaction fully
     excluded.
 
-    In addition to calculating energy and forces, this class can compute the electric field at arbitrary points in
-    space.  To do this, call compute_field().
+    In addition to calculating energy and forces, this class can compute the electric field and potential at arbitrary
+    points in space.  To do this, call compute_field() or compute_potential().
 
     When you create an instance of this class, you must specify the value of Coulomb's constant 1/(4*pi*eps0).  Its
     value depends on the units used for energy and distance.  The value you specify thus sets the unit system.  See the
@@ -180,6 +180,56 @@ class CoulombEwald(torch.nn.Module):
                 energy += self._compute_recip_energy_batch(positions, charges, dipoles, box_vectors, batch, num_systems)
         return self.prefactor*energy
 
+    def compute_potential(self, potential_positions: torch.Tensor, positions: torch.Tensor, charges: torch.Tensor,
+                          box_vectors: torch.Tensor, include_direct: bool = True, include_reciprocal: bool = True,
+                          dipoles: torch.Tensor | None = None) -> torch.Tensor:
+        """Compute the electric potential produced by the particles at a set of points.
+
+        Parameters
+        ----------
+        potential_positions: torch.Tensor
+            a Tensor of shape (n_points, 3) containing the positions at which to compute the potential
+        positions: torch.Tensor
+            a Tensor of shape (n_particles, 3) containing the Cartesian coordinates of each particle
+        charges:
+            a Tensor of shape (n_particles,) containing the charge of each particle
+        box_vectors: torch.Tensor
+            a Tensor of shape (3, 3) containing box vectors defining the periodic box.
+        include_direct: bool
+            specifies whether the direct space term should be included in the result
+        include_reciprocal: bool
+            specifies whether the reciprocal space term should be included in the result
+        dipoles: torch.Tensor | None
+            a Tensor of shape (n_particles, 3) containing the dipole moment of each particle.  If max_multipole is
+            'charge', this is ignored.
+
+        Returns
+        -------
+        torch.Tensor:
+            a Tensor of shape (n_points,) containing the electric potential at each of the points
+        """
+        if include_direct:
+            delta = periodic_displacements(potential_positions.view((-1,1,3))-positions, box_vectors)
+            r = torch.linalg.vector_norm(delta, dim=2, keepdim=True)
+            alphar = self.alpha*r
+            b0 = torch.erfc(alphar)/r
+            potential = charges.unsqueeze(1)*b0
+            if self.max_multipole != 'charge':
+                temp1 = 2*self.alpha/math.sqrt(math.pi)
+                expfactor = torch.exp(-alphar**2)
+                b1 = (b0 + temp1*expfactor)*r**-2
+                potential += (dipoles.unsqueeze(0)*delta).sum(axis=2, keepdim=True)*b1
+            potential = torch.where((r > 0)*(r < self.cutoff), potential, 0)
+            potential = potential.sum(dim=1).squeeze(1)
+        else:
+            potential = torch.zeros(potential_positions.shape[0], dtype=torch.float32, device=charges.device)
+        if include_reciprocal:
+            sum1, sum2, k, ak, recip_box_vectors = self._compute_recip_sums(positions, charges, dipoles, box_vectors)
+            phase = k@potential_positions.T
+            temp = 8*torch.pi*recip_box_vectors.diag().prod()*ak.unsqueeze(1)*(sum1.unsqueeze(1)*torch.cos(phase) + sum2.unsqueeze(1)*torch.sin(phase))
+            potential += temp.sum(dim=0)
+        return self.prefactor*potential
+
     def compute_field(self, field_positions: torch.Tensor, positions: torch.Tensor, charges: torch.Tensor,
                       box_vectors: torch.Tensor, include_direct: bool = True, include_reciprocal: bool = True,
                       dipoles: torch.Tensor | None = None) -> torch.Tensor:
@@ -233,7 +283,6 @@ class CoulombEwald(torch.nn.Module):
             field += (temp.unsqueeze(2)*k.unsqueeze(1)).sum(dim=0)
         return self.prefactor*field
 
-
     def _compute_recip_sums(self, positions: torch.Tensor, charges: torch.Tensor, dipoles: torch.Tensor | None,
                             box_vectors: torch.Tensor):
         recip_box_vectors = torch.linalg.inv(box_vectors)
@@ -250,13 +299,11 @@ class CoulombEwald(torch.nn.Module):
         ak = torch.exp(self._exp_coeff*k2)/k2
         return sum1, sum2, k, ak, recip_box_vectors
 
-
     def _compute_recip_energy(self, positions: torch.Tensor, charges: torch.Tensor, dipoles: torch.Tensor | None,
                               box_vectors: torch.Tensor):
         sum1, sum2, _, ak, recip_box_vectors = self._compute_recip_sums(positions, charges, dipoles, box_vectors)
         energy = torch.sum(ak*(sum1**2 + sum2**2))
         return energy*4*torch.pi*recip_box_vectors.diag().prod()
-
 
     def _compute_recip_energy_batch(self, positions: torch.Tensor, charges: torch.Tensor, dipoles: torch.Tensor | None,
                                     box_vectors: torch.Tensor, batch: torch.Tensor | None, num_systems: int):

--- a/mlipops/coulombnc.py
+++ b/mlipops/coulombnc.py
@@ -18,8 +18,8 @@ class CoulombNC(torch.nn.Module):
     You can optionally specify that certain interactions should be omitted when computing the energy.  This is typically
     used for nearby atoms within the same molecule.
 
-    In addition to calculating energy and forces, this class can compute the electric field at arbitrary points in
-    space.  To do this, call compute_field().
+    In addition to calculating energy and forces, this class can compute the electric field and potential at arbitrary
+    points in space.  To do this, call compute_field() or compute_potential().
 
     When you create an instance of this class, you must specify the value of Coulomb's constant 1/(4*pi*eps0).  Its
     value depends on the units used for energy and distance.  The value you specify thus sets the unit system.  See the
@@ -87,6 +87,36 @@ class CoulombNC(torch.nn.Module):
             params = (charges, dipoles)
         energy = self.pairwise(positions, params, neighbors, None, batch)
         return self.prefactor*energy
+
+    def compute_potential(self, potential_positions: torch.Tensor, positions: torch.Tensor, charges: torch.Tensor,
+                          dipoles: torch.Tensor | None = None) -> torch.Tensor:
+        """Compute the electric potential produced by the particles at a set of points.
+
+        Parameters
+        ----------
+        potential_positions: torch.Tensor
+            a Tensor of shape (n_points, 3) containing the positions at which to compute the potential
+        positions: torch.Tensor
+            a Tensor of shape (n_particles, 3) containing the Cartesian coordinates of each particle
+        charges:
+            a Tensor of shape (n_particles,) containing the charge of each particle
+        dipoles: torch.Tensor | None
+            a Tensor of shape (n_particles, 3) containing the dipole moment of each particle.  If max_multipole is
+            'charge', this is ignored.
+
+        Returns
+        -------
+        torch.Tensor:
+            a Tensor of shape (n_points,) containing the electric potential at each of the points
+        """
+        delta = periodic_displacements(potential_positions.view((-1,1,3))-positions, None)
+        r = torch.linalg.vector_norm(delta, dim=2)
+        potential = charges.unsqueeze(0)/r
+        if self.max_multipole != 'charge':
+            potential += (dipoles.unsqueeze(0)*delta).sum(dim=2)*r**-3
+        potential = torch.where((r > 0), potential, 0)
+        potential = potential.sum(dim=1)
+        return self.prefactor*potential
 
     def compute_field(self, field_positions: torch.Tensor, positions: torch.Tensor, charges: torch.Tensor,
                       dipoles: torch.Tensor | None = None) -> torch.Tensor:

--- a/mlipops/coulombpme.py
+++ b/mlipops/coulombpme.py
@@ -39,8 +39,8 @@ class CoulombPME(torch.nn.Module):
     Attempting to compute a second derivative will throw an exception.  This means that if you use PME during training,
     the loss function can only depend on energy, not forces.  Consider using CoulombEwald during training instead.
 
-    In addition to calculating energy and forces, this class can compute the electric field at arbitrary points in
-    space.  To do this, call compute_field().
+    In addition to calculating energy and forces, this class can compute the electric field and potential at arbitrary
+    points in space.  To do this, call compute_field() or compute_potential().
 
     When you create an instance of this class, you must specify the value of Coulomb's constant 1/(4*pi*eps0).  Its
     value depends on the units used for energy and distance.  The value you specify thus sets the unit system.  See the
@@ -218,6 +218,65 @@ class CoulombPME(torch.nn.Module):
                     energy -= (2/3)*sum_dipoles2*self.alpha**3/math.sqrt(torch.pi)
             energy += ReciprocalFunction.apply(self, positions, charges, dipoles, box_vectors, batch, num_systems)
         return self.prefactor*energy
+
+    def compute_potential(self, potential_positions: torch.Tensor, positions: torch.Tensor, charges: torch.Tensor,
+                          box_vectors: torch.Tensor, include_direct: bool = True, include_reciprocal: bool = True,
+                          dipoles: torch.Tensor | None = None) -> torch.Tensor:
+        """Compute the electric potential produced by the particles at a set of points.
+
+        Parameters
+        ----------
+        potential_positions: torch.Tensor
+            a Tensor of shape (n_points, 3) containing the positions at which to compute the potential
+        positions: torch.Tensor
+            a Tensor of shape (n_particles, 3) containing the Cartesian coordinates of each particle
+        charges:
+            a Tensor of shape (n_particles,) containing the charge of each particle
+        box_vectors: torch.Tensor
+            a Tensor of shape (3, 3) containing box vectors defining the periodic box.
+        include_direct: bool
+            specifies whether the direct space term should be included in the result
+        include_reciprocal: bool
+            specifies whether the reciprocal space term should be included in the result
+        dipoles: torch.Tensor | None
+            a Tensor of shape (n_particles, 3) containing the dipole moment of each particle.  If max_multipole is
+            'charge', this is ignored.
+
+        Returns
+        -------
+        torch.Tensor:
+            a Tensor of shape (n_points,) containing the electric potential at each of the points
+        """
+        if include_direct:
+            delta = periodic_displacements(potential_positions.view((-1,1,3))-positions, box_vectors)
+            r = torch.linalg.vector_norm(delta, dim=2, keepdim=True)
+            alphar = self.alpha*r
+            b0 = torch.erfc(alphar)/r
+            potential = charges.unsqueeze(1)*b0
+            if self.max_multipole != 'charge':
+                temp1 = 2*self.alpha/math.sqrt(math.pi)
+                expfactor = torch.exp(-alphar**2)
+                b1 = (b0 + temp1*expfactor)*r**-2
+                potential += (dipoles.unsqueeze(0)*delta).sum(axis=2, keepdim=True)*b1
+            potential = torch.where((r > 0)*(r < self.cutoff), potential, 0)
+            potential = potential.sum(dim=1).squeeze(1)
+        else:
+            potential = torch.zeros(potential_positions.shape[0], dtype=torch.float32, device=charges.device)
+        if include_reciprocal:
+            recip_box_vectors, _, _, _, _, _, recip_grid, eterm, transformed_dipoles = reciprocal_forward(self, positions, charges, dipoles, box_vectors, None, 1)
+            grid_size = (self.gridx, self.gridy, self.gridz)
+            grid_size_tensor = torch.tensor(grid_size, device=positions.device)
+            ti, _, data, ddata = compute_spline_coefficients(self, potential_positions, recip_box_vectors, grid_size_tensor, None)
+            grid = torch.fft.irfftn(recip_grid*eterm, grid_size, norm='forward')
+            num_points = potential_positions.shape[0]
+            charge_deriv = torch.zeros_like(potential)
+            if self.use_triton:
+                g = lambda meta: (triton.cdiv(num_points, meta['BLOCK_SIZE']),)
+                interp_derivatives_kernel[g](None, charge_deriv, grid, grid_size_tensor, data, ddata, ti, None, num_points, self.order, 256)
+            else:
+                interp_derivatives(None, charge_deriv, grid, grid_size_tensor, data, ddata, ti, None, self.order)
+            potential += charge_deriv
+        return self.prefactor*potential
 
     def compute_field(self, field_positions: torch.Tensor, positions: torch.Tensor, charges: torch.Tensor,
                       box_vectors: torch.Tensor, include_direct: bool = True, include_reciprocal: bool = True,

--- a/mlipops/coulombrf.py
+++ b/mlipops/coulombrf.py
@@ -16,8 +16,8 @@ class CoulombRF(torch.nn.Module):
     You can optionally specify that certain interactions should be omitted when computing the energy.  This is typically
     used for nearby atoms within the same molecule.
 
-    In addition to calculating energy and forces, this class can compute the electric field at arbitrary points in
-    space.  To do this, call compute_field().
+    In addition to calculating energy and forces, this class can compute the electric field and potential at arbitrary
+    points in space.  To do this, call compute_field() or compute_potential().
 
     When you create an instance of this class, you must specify the value of Coulomb's constant 1/(4*pi*eps0).  Its
     value depends on the units used for energy and distance.  The value you specify thus sets the unit system.  See the
@@ -88,6 +88,36 @@ class CoulombRF(torch.nn.Module):
         neighbors = self.neighbor_list(positions, box_vectors, batch)
         energy = self.pairwise(positions, charges, neighbors, box_vectors, batch)
         return self.prefactor*energy
+
+    def compute_potential(self, potential_positions: torch.Tensor, positions: torch.Tensor, charges: torch.Tensor,
+                          box_vectors: torch.Tensor) -> torch.Tensor:
+        """Compute the electric potential produced by the particles at a set of points.
+
+        Parameters
+        ----------
+        potential_positions: torch.Tensor
+            a Tensor of shape (n_points, 3) containing the positions at which to compute the potential
+        positions: torch.Tensor
+            a Tensor of shape (n_particles, 3) containing the Cartesian coordinates of each particle
+        charges:
+            a Tensor of shape (n_particles,) containing the charge of each particle
+        box_vectors: torch.Tensor
+            a Tensor of shape (3, 3) containing box vectors defining the periodic box.  If None, periodic boundary
+            conditions are not used.
+
+        Returns
+        -------
+        torch.Tensor:
+            a Tensor of shape (n_points,) containing the electric potential at each of the points
+        """
+        delta = periodic_displacements(potential_positions.view((-1,1,3))-positions, box_vectors)
+        r = torch.linalg.vector_norm(delta, dim=2, keepdim=True)
+        k = self.pairwise.computation.k
+        c = self.pairwise.computation.c
+        potential = charges.unsqueeze(1)*(1/r + k*r**2 - c)
+        potential = torch.where((r > 0)*(r < self.cutoff), potential, 0)
+        potential = potential.sum(dim=1)
+        return self.prefactor*potential
 
     def compute_field(self, field_positions: torch.Tensor, positions: torch.Tensor, charges: torch.Tensor,
                       box_vectors: torch.Tensor) -> torch.Tensor:

--- a/tests/TestChargeEquilibration.py
+++ b/tests/TestChargeEquilibration.py
@@ -187,3 +187,17 @@ def test_qeq_derivatives(device, method, periodic):
     c1 = eq(positions, electronegativity, hardness, radius+0.5*delta*radius_grad/norm, 0, box_vectors=box_vectors)
     c2 = eq(positions, electronegativity, hardness, radius-0.5*delta*radius_grad/norm, 0, box_vectors=box_vectors)
     assert torch.allclose((c1*c1).sum() - (c2*c2).sum(), norm*delta, rtol=1e-2)
+
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_qeq_external_potential(device):
+    """Test the QEq algorithm with an external electric potential."""
+    if not torch.cuda.is_available() and device == 'cuda':
+        pytest.skip('No GPU')
+    positions, electronegativity, hardness, radius = get_nh3_tensors(device)
+    coulomb = CoulombNC(None, 1.0, device=device)
+    eq = ChargeEquilibration(coulomb)
+    field = torch.tensor([-1.0, 0.0, 0.0], dtype=torch.float32, device=device)
+    potential = -(positions*field).sum(axis=1)
+    charges = eq(positions, electronegativity, hardness, radius, 0, potential=potential)
+    assert torch.all(charges[[0,2,3,4]] > charges[[1,5,6,7]])

--- a/tests/TestCoulombEwald.py
+++ b/tests/TestCoulombEwald.py
@@ -319,7 +319,7 @@ def test_batch(device, max_multipole):
 @pytest.mark.parametrize('device', ['cpu', 'cuda'])
 @pytest.mark.parametrize('include_direct, include_reciprocal', [(True,False), (False,True), (True,True)])
 def test_compute_field(device, include_direct, include_reciprocal):
-    """Test computing the electric field."""
+    """Test computing the electric field and potential."""
     if not torch.cuda.is_available() and device == 'cuda':
         pytest.skip('No GPU')
     positions = 3*torch.rand((30, 3), dtype=torch.float32, device=device)-1
@@ -347,6 +347,14 @@ def test_compute_field(device, include_direct, include_reciprocal):
         diffnorm = torch.linalg.vector_norm(f1-f2)/norm1
         assert torch.allclose(norm1, norm2, rtol=5e-3)
         assert diffnorm < 5e-3
+
+    # The field should equal the negative gradient of the potential.
+
+    field_positions.requires_grad_(True)
+    potential = ewald.compute_potential(field_positions, positions, charges, box_vectors, include_direct, include_reciprocal, dipoles)
+    for i in range(field_positions.shape[0]):
+        potential_grad = torch.autograd.grad(potential[i], field_positions, retain_graph=True)[0]
+        assert torch.allclose(-potential_grad[i], field[i], rtol=1e-3)
 
 
 @pytest.mark.parametrize('device', ['cpu', 'cuda'])

--- a/tests/TestCoulombNC.py
+++ b/tests/TestCoulombNC.py
@@ -153,7 +153,7 @@ def test_batch(device):
 @pytest.mark.parametrize('device', ['cpu', 'cuda'])
 @pytest.mark.parametrize('max_multipole', ['charge', 'dipole'])
 def test_compute_field(device, max_multipole):
-    """Test computing the electric field."""
+    """Test computing the electric field and potential."""
     if not torch.cuda.is_available() and device == 'cuda':
         pytest.skip('No GPU')
     positions = 3*torch.rand((30, 3), dtype=torch.float32, device=device)-1
@@ -178,6 +178,14 @@ def test_compute_field(device, max_multipole):
         diffnorm = torch.linalg.vector_norm(f1-f2)/norm1
         assert torch.allclose(norm1, norm2, rtol=5e-3)
         assert diffnorm < 5e-3
+
+    # The field should equal the negative gradient of the potential.
+
+    field_positions.requires_grad_(True)
+    potential = coulomb.compute_potential(field_positions, positions, charges, dipoles)
+    for i in range(field_positions.shape[0]):
+        potential_grad = torch.autograd.grad(potential[i], field_positions, retain_graph=True)[0]
+        assert torch.allclose(-potential_grad[i], field[i], rtol=1e-3)
 
 
 @pytest.mark.parametrize('device', ['cpu', 'cuda'])

--- a/tests/TestCoulombPme.py
+++ b/tests/TestCoulombPme.py
@@ -416,7 +416,7 @@ def test_batch(device, max_multipole):
 @pytest.mark.parametrize('device', ['cpu', 'cuda'])
 @pytest.mark.parametrize('include_direct, include_reciprocal', [(True,False), (False,True), (True,True)])
 def test_compute_field(device, include_direct, include_reciprocal):
-    """Test computing the electric field."""
+    """Test computing the electric field and potential."""
     if not torch.cuda.is_available() and device == 'cuda':
         pytest.skip('No GPU')
     positions = 3*torch.rand((30, 3), dtype=torch.float32, device=device)-1
@@ -444,6 +444,19 @@ def test_compute_field(device, include_direct, include_reciprocal):
         diffnorm = torch.linalg.vector_norm(f1-f2)/norm1
         assert torch.allclose(norm1, norm2, rtol=5e-3)
         assert diffnorm < 5e-3
+
+    # The field should equal the negative gradient of the potential.
+
+    delta = 0.001
+    for i in range(field_positions.shape[0]):
+        for j in range(3):
+            pos1 = field_positions.clone()
+            pos1[i,j] += delta
+            pot1 = pme.compute_potential(pos1, positions, charges, box_vectors, include_direct, include_reciprocal, dipoles)
+            pos1 = field_positions.clone()
+            pos1[i,j] -= delta
+            pot2 = pme.compute_potential(pos1, positions, charges, box_vectors, include_direct, include_reciprocal, dipoles)
+            assert torch.allclose(pot1[i]+2*delta*field[i,j], pot2[i], rtol=1e-2, atol=0.1)
 
 
 @pytest.mark.parametrize('device', ['cpu', 'cuda'])

--- a/tests/TestCoulombRF.py
+++ b/tests/TestCoulombRF.py
@@ -165,7 +165,7 @@ def test_batch(device, periodic):
 
 @pytest.mark.parametrize('device', ['cpu', 'cuda'])
 def test_compute_field(device):
-    """Test computing the electric field."""
+    """Test computing the electric field and potential."""
     if not torch.cuda.is_available() and device == 'cuda':
         pytest.skip('No GPU')
     positions = 3*torch.rand((30, 3), dtype=torch.float32, device=device)-1
@@ -191,6 +191,14 @@ def test_compute_field(device):
         diffnorm = torch.linalg.vector_norm(f1-f2)/norm1
         assert torch.allclose(norm1, norm2, rtol=5e-3)
         assert diffnorm < 5e-3
+
+    # The field should equal the negative gradient of the potential.
+
+    field_positions.requires_grad_(True)
+    potential = rf.compute_potential(field_positions, positions, charges, box_vectors)
+    for i in range(field_positions.shape[0]):
+        potential_grad = torch.autograd.grad(potential[i], field_positions, retain_graph=True)[0]
+        assert torch.allclose(-potential_grad[i], field[i], rtol=1e-3)
 
 
 @pytest.mark.parametrize('device', ['cpu', 'cuda'])


### PR DESCRIPTION
This adds two related features.  ChargeEquilibration now lets you specify an external potential that should polarize the system.  One of the main uses of this feature is ML/MM simulations where the MM charges should polarize the ML region.  To enable that, I also added a `compute_potential()` method to all the Coulomb classes.  They already had `compute_field()`, but for this purpose you need the potential instead of the field.