### PR TITLE
Added option for default charges

### DIFF
--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -303,6 +303,13 @@ potential = coulomb.compute_potential(ml_positions, mm_positions, mm_charges)
 ml_charges = eq(ml_positions, electronegativity, hardness, radius, total_charge=0, potential=potential)
 ```
 
+Another option is to specify a default charge $q^0_i$ for every atom.  In that case, the energy function is modified to
+
+$E = E_{coul}(r, q, \alpha) + \sum_{i} \left[ \chi_i (q_i - q^0_i) + \frac{1}{2} \left( J_{ii} + \frac{\sqrt{2}}{\sqrt{\pi} \alpha_i} \right) (q_i - q^0_i)^2 \right]$
+
+In some cases, using nonzero default charges (for example, the formal oxidation state of each atom) can lead to more
+accurate results.
+
 ### Dispersion
 
 Dispersion energy can be computed using the DFT-D3(BJ) model.  Using it is similar to the Coulomb examples shown above,

--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -303,7 +303,13 @@ potential = coulomb.compute_potential(ml_positions, mm_positions, mm_charges)
 ml_charges = eq(ml_positions, electronegativity, hardness, radius, total_charge=0, potential=potential)
 ```
 
-Another option is to specify a default charge $q^0_i$ for every atom.  In that case, the energy function is modified to
+Another option is to specify a default charge $q^0_i$ for every atom.
+
+```python
+charges = eq(positions, electronegativity, hardness, radius, total_charge=0, default_charge=default_charge)
+```
+
+In that case, the energy function is modified to
 
 $E = E_{coul}(r, q, \alpha) + \sum_{i} \left[ \chi_i (q_i - q^0_i) + \frac{1}{2} \left( J_{ii} + \frac{\sqrt{2}}{\sqrt{\pi} \alpha_i} \right) (q_i - q^0_i)^2 \right]$
 

--- a/mlipops/chargeequilibration.py
+++ b/mlipops/chargeequilibration.py
@@ -28,6 +28,10 @@ class ChargeEquilibration(torch.nn.Module):
     be computed from a uniform external field, or by calling compute_potential() on a Coulomb calculation object to get
     the potential resulting from a set of external charges.
 
+    You can optionally specify a default charge for each atom.  The energy function is then modified as described in
+    https://doi.org/10.1021/jz3008485 to bias each atom towards its default charge.  In some cases, using nonzero
+    default charges (for example, the formal oxidation state of each atom) can lead to more accurate results.
+
     This class offers a choice of method for solving the system of equations.  By default it uses torch.linalg.solve(),
     which implements a direct algorithm.  It is accurate and generally robust, but it can be slow, especially for large
     systems.  Alternatively you can choose MINRES, an efficient iterative algorithm.  It can be much faster in some
@@ -49,7 +53,8 @@ class ChargeEquilibration(torch.nn.Module):
     def forward(self, positions: torch.Tensor, electronegativity: torch.Tensor, hardness: torch.Tensor,
                 radius: torch.Tensor, total_charge: float | torch.Tensor | None = None, molecules: list | None = None,
                 box_vectors: torch.Tensor | None = None, potential: torch.Tensor | None = None,
-                batch: torch.Tensor | None = None, solver: str = 'direct') -> torch.Tensor:
+                default_charge: torch.Tensor | None = None, batch: torch.Tensor | None = None,
+                solver: str = 'direct') -> torch.Tensor:
         """Perform charge equilibration to compute atomic partial charges.
 
         Parameters
@@ -76,6 +81,9 @@ class ChargeEquilibration(torch.nn.Module):
             boundary conditions are not used.
         potential: torch.Tensor
             a Tensor of shape (n_particles,) containing the external electric potential at the location of each particle
+        default_charge: torch.Tensor | None
+            a Tensor of shape (n_particles,) containing the default charge of every particle.  If None, all default
+            charges are 0.
         solver: str
             the method to use for solving the system of equations.  Options are 'direct' (use torch.linalg.solve() to
             directly compute the result) and 'minres' (an iterative solver that tends to be faster, especially for large
@@ -141,6 +149,8 @@ class ChargeEquilibration(torch.nn.Module):
         rhs = electronegativity
         if potential is not None:
             rhs = rhs+potential
+        if default_charge is not None:
+            rhs = rhs-interaction.diag()*default_charge
         x = torch.cat([-rhs, mol_charges])
 
         # Solve the system of equations.

--- a/mlipops/minres.py
+++ b/mlipops/minres.py
@@ -147,27 +147,25 @@ def minres(A, b, M=None, x0=None, tol=1e-5, maxiters=None):
         if ynorm.max() == 0 or Anorm == 0:
             test1 = torch.inf
         else:
-            test1 = rnorm / (Anorm * ynorm)
-
+            test1 = (rnorm / (Anorm * ynorm)).max()
+        if test1 <= tol:
+            break
         if Anorm == 0:
             test2 = torch.inf
         else:
-            test2 = root / Anorm
-        Acond = gmax / gmin
-        t1 = 1 + test1.max()
-        t2 = 1 + test2.max()
-        if t2 <= 1:
+            test2 = (root / Anorm).max()
+        if test2 <= tol:
             break
-        if t1 <= 1:
-            break
-
-        if Acond >= 0.1 / eps:
-            assert False, "System is ill-conditioned."
         if (epsx >= beta1).any():
             assert False
-        if test2.max() <= tol:
+        Acond = gmax / gmin
+        if Acond >= 0.1 / eps:
+            assert False, "System is ill-conditioned."
+        t1 = 1 + test1
+        if t1 <= 1:
             break
-        if test1.max() <= tol:
+        t2 = 1 + test2
+        if t2 <= 1:
             break
     return x
 

--- a/tests/TestChargeEquilibration.py
+++ b/tests/TestChargeEquilibration.py
@@ -22,8 +22,9 @@ def get_nh3_tensors(device):
     return positions, electronegativity, hardness, radius
 
 
-def validate_minimization(coulomb, positions, charges, box_vectors, hardness, electronegativity, radius):
-    e0 = coulomb(positions, charges, box_vectors) + (electronegativity*charges + 0.5*hardness*charges**2).sum()
+def validate_minimization(coulomb, positions, charges, box_vectors, hardness, electronegativity, radius, default_charge=None):
+    dq = charges if default_charge is None else charges-default_charge
+    e0 = coulomb(positions, charges, box_vectors) + (electronegativity*dq + 0.5*hardness*dq**2).sum()
     for _ in range(10):
         # Add a random offset to the charges and confirm that the energy increases.  This isn't strictly guaranteed,
         # since the minimization is based on Gaussian charges instead of point charges, so include a small margin.
@@ -31,7 +32,8 @@ def validate_minimization(coulomb, positions, charges, box_vectors, hardness, el
         delta = 0.1*torch.randn_like(charges)
         delta -= torch.mean(delta)
         c2 = charges+delta
-        e2 = coulomb(positions, c2, box_vectors) + (electronegativity*c2 + 0.5*(hardness+(math.sqrt(2/torch.pi)/radius))*c2**2).sum()
+        dq = c2 if default_charge is None else c2-default_charge
+        e2 = coulomb(positions, c2, box_vectors) + (electronegativity*dq + 0.5*(hardness+(math.sqrt(2/torch.pi)/radius))*dq**2).sum()
         assert e2 > e0-0.05
 
 
@@ -202,6 +204,25 @@ def test_qeq_external_potential(device):
     potential = -(positions*field).sum(axis=1)
     charges = eq(positions, electronegativity, hardness, radius, 0, potential=potential)
     assert torch.all(charges[[0,2,3,4]] > charges[[1,5,6,7]])
+
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_qeq_default_charges(device):
+    """Test the QEq algorithm with default charges."""
+    if not torch.cuda.is_available() and device == 'cuda':
+        pytest.skip('No GPU')
+    positions, electronegativity, hardness, radius = get_nh3_tensors(device)
+    coulomb = CoulombNC(None, 1.0, device=device)
+    eq = ChargeEquilibration(coulomb)
+    default_charge = torch.tensor([-1.0]+[0.0]*7, dtype=torch.float32, device=device)
+    charges = eq(positions, electronegativity, hardness, radius, 0, default_charge=default_charge)
+    assert torch.allclose(charges.sum(), torch.tensor(0.0), atol=1e-4)
+    assert charges[0] < charges[1]
+    validate_minimization(coulomb, positions, charges, None, hardness, electronegativity, radius, default_charge)
+    charges = eq(positions, electronegativity, hardness, radius, -1, default_charge=default_charge)
+    assert torch.allclose(charges.sum(), torch.tensor(-1.0), atol=1e-4)
+    assert charges[0] < charges[1]
+    validate_minimization(coulomb, positions, charges, None, hardness, electronegativity, radius, default_charge)
 
 
 @pytest.mark.parametrize('device', ['cpu', 'cuda'])


### PR DESCRIPTION
This adds another option to ChargeEquilibration.  You can specify a default charge for each atom (e.g. a formal oxidation state), and the charge is biased toward that value instead of toward 0.